### PR TITLE
규빈

### DIFF
--- a/Client/Code/EffectSpark.cpp
+++ b/Client/Code/EffectSpark.cpp
@@ -121,16 +121,16 @@ void CEffectSpark::Set_ParticleParam()
 	tParam.eShape = CParticleSystem::SHAPE::CIRCLE;
 
 	tParam.tInit.tCircle.fHeight = 1.f;
-	tParam.tInit.tCircle.fRadius = 3.f;
+	tParam.tInit.tCircle.fRadius = 4.f;
 
 	tParam.vVelocityNoise = { 0.f, 0.5f, 0.f };
 	tParam.vColor = _vec4(1.0f, 0.884f, 0.525f, 1.f);
 	tParam.vColorFade = _vec4(0.917f, 0.35f, 0.f, 1.f);
-	tParam.iTotalCnt = 200;
+	tParam.iTotalCnt = 75;
 
 	tParam.fSize = 0.075f;
 	tParam.fSizeFade = 0.00f;
-	tParam.fLifeTime = 0.75f;
+	tParam.fLifeTime = 0.4f;
 
 	tParam.fEmitRate = 20.f;
 	tParam.iEmitCnt = 5;
@@ -158,16 +158,16 @@ void CEffectSpark::Set_ParticleBloomParam()
 	tParam.eShape = CParticleSystem::SHAPE::CIRCLE;
 
 	tParam.tInit.tCircle.fHeight = 1.f;
-	tParam.tInit.tCircle.fRadius = 3.f;
+	tParam.tInit.tCircle.fRadius = 4.f;
 
 	tParam.vVelocityNoise = { 0.f, 0.5f, 0.f };
 	tParam.vColor = _vec4(1.0f, 0.884f, 0.525f, 1.f);
 	tParam.vColorFade = _vec4(0.917f, 0.35f, 0.f, 1.f);
-	tParam.iTotalCnt = 50;
+	tParam.iTotalCnt = 25;
 
-	tParam.fSize = 0.2f;
+	tParam.fSize = 0.3f;
 	tParam.fSizeFade = 0.00f;
-	tParam.fLifeTime = 0.5f;
+	tParam.fLifeTime = 0.2f;
 
 	tParam.fEmitRate = 20.f;
 	tParam.iEmitCnt = 5;

--- a/Client/Code/FilterFundo.cpp
+++ b/Client/Code/FilterFundo.cpp
@@ -31,7 +31,9 @@ HRESULT CFilterFundo::Ready_GameObject()
 
     m_pTransformCom->Set_Pos(3.f, 2.f, 3.f);
     m_pTransformCom->Set_Scale(1.f, 1.f, 1.f);
-    m_fViewZ = 1000.0f;
+    // 이 필터가 항상 무족권 알파 소팅되었을 때 첫번째이어야함
+    // 이유는 모름 무적권 alpha 렌더 그룹중엔 무적권 첫번째로 나와야 다른것들도 보임
+    m_fViewZ = 10000000000.0f;
 
     return S_OK;
 }

--- a/Client/Code/Player.cpp
+++ b/Client/Code/Player.cpp
@@ -10,6 +10,9 @@
 #include "../Header/DrinkMachine.h"
 #include "../Header/Item.h"
 
+#include"../Header/Wall.h"
+#include"../Header/WallTB.h"
+
 CPlayer::CPlayer(LPDIRECT3DDEVICE9 _pGraphicDev)
 	: Engine::CCharacter(_pGraphicDev)
 	, m_pRight_TransformCom(nullptr)
@@ -717,6 +720,35 @@ void CPlayer::Mouse_Move(const _float& _fTimeDelta)
 				static_cast<CTransform*>(pComponent)->Set_Pos(vPos);
 				pGameObject = static_cast<CTransform*>(pComponent)->GetOwner();
 				static_cast<CEffectPool*>(pGameObject)->Operate();
+			}
+			else // 레이캐스팅 -> 몬스터가 검출되지 않은 경우에
+			{
+				// 규빈 - 벽 스파크
+				CGameObject* pGameObject(nullptr);
+				CComponent* pComponent(nullptr);
+				CWall* pWall(nullptr);
+				CWallTB* pWallTB(nullptr);
+
+				_float fDist = 0.f;
+				_vec3 vHitPosition;
+				D3DXVec3Normalize(&RayDir, &RayDir);
+				pGameObject = Engine::CCollisionManager::GetInstance()->RayCastWall(RayStart + _vec3(0.f, 0.5f, 0.f), RayDir, &vHitPosition);
+				//pGameObject->OnCollisionEnter(*m_pColliderCom);
+				pWall = dynamic_cast<CWall*>(pGameObject);
+				pWallTB = dynamic_cast<CWallTB*>(pGameObject);
+
+				_vec3 vNormal{ 0.f, 0.f, 0.f };
+				if (pWall)
+					vNormal = pWall->Get_TileDirection();
+				if (pWallTB)
+					vNormal = pWallTB->Get_TileDirection();
+
+				pComponent = Engine::Get_Component(COMPONENTID::ID_DYNAMIC, L"Layer_Effect", L"EffectPool_Spark", L"Com_Transform");
+				static_cast<CTransform*>(pComponent)->Set_Pos(vHitPosition);
+				static_cast<CTransform*>(pComponent)->Set_Angle(-D3DX_PI * 0.5f * vNormal.z, 0.f, D3DX_PI * 0.5f * vNormal.x);
+				pGameObject = static_cast<CTransform*>(pComponent)->GetOwner();
+				static_cast<CEffectPool*>(pGameObject)->Operate();
+
 			}
 		}
 	}

--- a/Client/Code/Stage.cpp
+++ b/Client/Code/Stage.cpp
@@ -396,9 +396,9 @@ HRESULT CStage::Ready_Layer_Effect(const _tchar* _pLayerTag)
 	//m_mapLayer.insert({ _pLayerTag , pLayer });
 
 
-	//pGameObject = CFilterFundo::Create(m_pGraphicDev);
-	//NULL_CHECK_RETURN(pGameObject, E_FAIL);
-	//FAILED_CHECK_RETURN(pLayer->Add_GameObject(L"FilterFundo", pGameObject), E_FAIL);
+	pGameObject = CFilterFundo::Create(m_pGraphicDev);
+	NULL_CHECK_RETURN(pGameObject, E_FAIL);
+	FAILED_CHECK_RETURN(pLayer->Add_GameObject(L"FilterFundo", pGameObject), E_FAIL);
 
 	pGameObject = CEffectPool::Create(m_pGraphicDev, (CGameObject * (*)(LPDIRECT3DDEVICE9))CEffectMinigunShell::Create);
 	NULL_CHECK_RETURN(pGameObject, E_FAIL);

--- a/Engine/Header/CollisionManager.h
+++ b/Engine/Header/CollisionManager.h
@@ -53,6 +53,8 @@ public:
 
 	CGameObject* FloorRayCast2(_vec3 vRayStart);//산성, 용암 바닥 타일 정보 가져오기 위해 만듬
 
+	CGameObject* RayCastWall(_vec3 vRayStart, _vec3 vRayDir, _vec3* _vPos); // 벽 스파크 튀기는거
+
 public:
 	virtual void Free();
 


### PR DESCRIPTION
스파크 벽에 튀기도록 충돌 작업 (collisionmanager.cpp -> RayCastWall)
멋쟁이 필터 씌어봤는데 최신버전 이전에서는 작동하다가 이번 버전에서는 필터때문에 다른 게임 오브젝트들이 가려져서 우선 스테이지에 추가 안하고 주석 걸었씁니다.

멋쟁이 필터가 무조건 알파 렌더 그룹에서 첫번재로 렌더링 되어야 다른 것들이 가려지지 않는다.
이전 커밋에서 두번째로 렌더링되었는데 아무것도 안보였음 .. 원인은 더 알아봐야함