### PR TITLE
규빈

### DIFF
--- a/Client/Code/Boss_Humanoid.cpp
+++ b/Client/Code/Boss_Humanoid.cpp
@@ -447,6 +447,13 @@ void CBoss_Humanoid::Attack(const _float& _fTimeDelta)
 			if (Engine::RayCast(vPos, vDir)) {
 				CPlayer* m_pPlayer = static_cast<CPlayer*>(Engine::Get_CurrScene()->Get_GameObject(L"Layer_Player", L"Player"));
 				m_pPlayer->Set_PlayerHP(m_pPlayer->Get_PlayerHP() - 1.f);
+
+				// 규빈 : 플레이어 피격 이펙트
+				CComponent* pComponent = Engine::Get_Component(COMPONENTID::ID_DYNAMIC, L"Layer_Effect", L"EffectPlayerBlood", L"Com_Effect");
+				static_cast<CEffect*>(pComponent)->Set_Visibility(TRUE);
+
+				pComponent = Engine::Get_Component(COMPONENTID::ID_DYNAMIC, L"Layer_Effect", L"EffectRedFlash", L"Com_Effect");
+				static_cast<CEffect*>(pComponent)->Operate_Effect();
 			}
 		}
 	}

--- a/Client/Code/Boss_Robot.cpp
+++ b/Client/Code/Boss_Robot.cpp
@@ -201,6 +201,10 @@ void CBoss_Robot::Damaged_By_Player(const DAMAGED_STATE& _eDamagedState, const _
 	{
 		m_eCurState = BOSS_DEAD;
 		m_bIsDead = true;
+
+		// º¸½º Æø¹ß
+		CComponent* pComponent = Engine::Get_Component(COMPONENTID::ID_DYNAMIC, L"Layer_Effect", L"EffectBossRobotDie", L"Com_Effect");
+		static_cast<CEffect*>(pComponent)->Operate_Effect();
 	}
 
 }

--- a/Client/Code/EffectLaserTarget.cpp
+++ b/Client/Code/EffectLaserTarget.cpp
@@ -192,11 +192,12 @@ void CEffectLaserTarget::Set_ParticleSparkParameter()
 	tParam.tInit.tSphere.fRadius = 10.6f;
 	tParam.tInit.tSphere.fTheta = D3DX_PI / 6.f;
 	tParam.vColor = _vec4(1.0f, 0.461f, 0.461f, 1.f);
-	tParam.vColorFade = _vec4(0.917f, 0.35f, 0.0f, 1.f);
+	tParam.vColorFade = _vec4(0.917f, 0.35f, 0.0f, 0.f);
 	tParam.iTotalCnt = 500;
 
 	tParam.fSize = 0.5f;
-	tParam.fLifeTime = 0.45f;
+	//tParam.fLifeTime = 0.45f;
+	tParam.fLifeTime = 1.f;
 
 	tParam.fEmitRate = 100.;
 	tParam.iEmitCnt = 10.f;
@@ -213,7 +214,6 @@ void CEffectLaserTarget::Set_ParticleSparkParameter()
 	m_pParticleSystemComSpark->Set_Option(CParticleSystem::OPTION::GRAVITY, TRUE);
 
 	m_pParticleSystemComSpark->SetUp_Particle();
-
 }
 
 void CEffectLaserTarget::OnOperate(void* _pParam)

--- a/Client/Code/Laser.cpp
+++ b/Client/Code/Laser.cpp
@@ -73,6 +73,9 @@ _int CLaser::Update_GameObject(const _float& _fTimeDelta)
 			// ±‘∫Û : «√∑π¿ÃæÓ ««∞› ¿Ã∆Â∆Æ
 			CComponent* pComponent = Engine::Get_Component(COMPONENTID::ID_DYNAMIC, L"Layer_Effect", L"EffectPlayerBlood", L"Com_Effect");
 			static_cast<CEffect*>(pComponent)->Set_Visibility(TRUE);
+
+			pComponent = Engine::Get_Component(COMPONENTID::ID_DYNAMIC, L"Layer_Effect", L"EffectRedFlash", L"Com_Effect");
+			static_cast<CEffect*>(pComponent)->Operate_Effect();
 	
 		}
 		// ±‘∫Û


### PR DESCRIPTION
빌딩 스테이지에서 플레이어 피격시 이펙트 넣기
보스 스테이지에서 레이저에 의한 피격 이펙트 (빨간 플래쉬 넣엇음)
레이저 공격 파티클 더 잘보이게 만들기 ->파티클의 지속시간 1초로 늘림, 투명하게 color fade 보스 죽을때  폭발 넣기